### PR TITLE
Manually apply Rebuild for libabseil 20240722, libgrp 1.65 & libprotobuf 5.27.5 migration

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -23,7 +23,7 @@ jsoncpp:
 libcurl:
 - '8'
 libprotobuf:
-- 4.25.3
+- 5.27.5
 libzip:
 - '1'
 target_platform:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -27,7 +27,7 @@ jsoncpp:
 libcurl:
 - '8'
 libprotobuf:
-- 4.25.3
+- 5.27.5
 libzip:
 - '1'
 target_platform:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -23,7 +23,7 @@ jsoncpp:
 libcurl:
 - '8'
 libprotobuf:
-- 4.25.3
+- 5.27.5
 libzip:
 - '1'
 target_platform:

--- a/.ci_support/migrations/libabseil20240722_grpc165_libprotobuf5275.yaml
+++ b/.ci_support/migrations/libabseil20240722_grpc165_libprotobuf5275.yaml
@@ -1,0 +1,18 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for libabseil 20240722, libgrp 1.65 & libprotobuf 5.27.5
+  kind: version
+  migration_number: 1
+  exclude:
+    - abseil-cpp
+    - grpc-cpp
+    - libprotobuf
+    - protobuf
+    - re2
+libabseil:
+- 20240722
+libgrpc:
+- "1.65"
+libprotobuf:
+- 5.27.5
+migrator_ts: 1727040240.8650293

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -23,7 +23,7 @@ jsoncpp:
 libcurl:
 - '8'
 libprotobuf:
-- 4.25.3
+- 5.27.5
 libzip:
 - '1'
 macos_machine:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -23,7 +23,7 @@ jsoncpp:
 libcurl:
 - '8'
 libprotobuf:
-- 4.25.3
+- 5.27.5
 libzip:
 - '1'
 macos_machine:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -13,7 +13,7 @@ jsoncpp:
 libcurl:
 - '8'
 libprotobuf:
-- 4.25.3
+- 5.27.5
 libzip:
 - '1'
 target_platform:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
     sha256: 47fc53b1628b6d2baa4b769f80286a94290979adbafeea0e07cd8b0a53f237c6
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: {{ cxx_name }}


### PR DESCRIPTION
The migration was manually removed in https://github.com/conda-forge/gz-fuel-tools-feedstock/pull/39 as a workaround for https://github.com/conda-forge/gz-common-feedstock/issues/48, but now that  https://github.com/conda-forge/gz-common-feedstock/issues/48 was solved we can re-enable it.


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
